### PR TITLE
typo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ],
+  "presets": [
+    "@babel/preset-env"
+  ]
+}

--- a/.babelsrc
+++ b/.babelsrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}


### PR DESCRIPTION
file should be called .babelrc instead of .babelsrc (without the s)
